### PR TITLE
Updated Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-# Use an official OpenJDK runtime as a parent image
-FROM openjdk:17-jdk-alpine
+# Use an official BellSoft Liberica runtime as a parent image
+FROM bellsoft/liberica-openjdk-alpine:17
 
 # Set the working directory inside the container
 WORKDIR /app
 
-# Copy the project JAR file into the container at /app
+# Copy the project JAR file into the container
 COPY target/Project2-0.0.1-SNAPSHOT.jar app.jar
 
-# Expose the port your Spring Boot app runs on
-EXPOSE 8080
+# Run the jar file (relying on Heroku's PORT environment variable)
+ENTRYPOINT ["java", "-Dserver.port=${PORT:-8080}", "-jar", "/app/app.jar"]
 
-# Run the jar file
-ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
**Description:**
This pull request updates the Dockerfile to improve compatibility and support for Heroku deployment by switching to the BellSoft Liberica OpenJDK runtime and configuring the application to use the Heroku `PORT` environment variable, removing the previously hardcoded port.

**Key Changes:**

- **Base Image Change**:
  - Updated the parent image from `openjdk:17-jdk-alpine` to `bellsoft/liberica-openjdk-alpine:17` for a more efficient runtime on Alpine Linux.

- **Heroku Port Support**:
  - Removed the hardcoded port (`8080`) and modified the `ENTRYPOINT` to include `-Dserver.port=${PORT:-8080}`. This allows the application to dynamically bind to the port specified by Heroku through the `PORT` environment variable. If the `PORT` variable is not set, it will default to port 8080.
  - This change is necessary because Heroku dynamically assigns a port for each application instance, so hardcoding a specific port would prevent the application from starting correctly on Heroku.

- **Structure Retained**:
  - The working directory is set to `/app` and the JAR file is copied as before.

This update ensures that the application can run properly on Heroku by dynamically binding to the port Heroku assigns, while improving the runtime efficiency with the BellSoft Liberica base image.
