### PR TITLE
Created Makefile for Building and Deploying Docker Image to Heroku

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Makefile for building and deploying the Docker image
+
+# Variables
+IMAGE_NAME = project2
+HEROKU_APP_NAME = cst438-project2
+HEROKU_REGISTRY = registry.heroku.com/$(HEROKU_APP_NAME)/web
+
+# Default target
+all: build tag push release open
+
+# Build the Docker image (force no cache to ensure fresh image)
+build:
+	echo "Building Docker image for $(IMAGE_NAME)..."
+	docker build --no-cache --platform linux/amd64 -t $(IMAGE_NAME) .
+
+# Tag the Docker image
+tag:
+	echo "Tagging Docker image..."
+	docker tag $(IMAGE_NAME) $(HEROKU_REGISTRY)
+
+# Push the Docker image to Heroku
+push:
+	echo "Pushing Docker image to Heroku..."
+	docker push $(HEROKU_REGISTRY)
+
+# Release the Docker image on Heroku and restart the app
+release:
+	echo "Releasing Docker image on Heroku..."
+	heroku container:release web --app $(HEROKU_APP_NAME)
+#	echo "Checking Heroku logs..."
+#	heroku logs --tail --app $(HEROKU_APP_NAME)
+
+# Open the Heroku app
+open:
+	echo "Opening Heroku app..."
+	heroku open --app $(HEROKU_APP_NAME)
+
+# Clean up (optional)
+clean:
+	echo "Cleaning up..."
+	docker rmi $(HEROKU_REGISTRY) || true


### PR DESCRIPTION
**Description:**
This pull request adds a `Makefile` that automates the process of building, tagging, pushing, and releasing the Docker image to Heroku, simplifying the deployment process.

**Key Features:**

- **Build Docker Image**:
  - The `build` target builds the Docker image for `project2` using `docker build` with the `--no-cache` flag to ensure a fresh build and targets the `linux/amd64` platform.

- **Tag and Push Docker Image**:
  - The `tag` target tags the Docker image for deployment to the Heroku container registry.
  - The `push` target pushes the image to the Heroku container registry.

- **Release and Open App on Heroku**:
  - The `release` target releases the pushed image to Heroku and restarts the app.
  - The `open` target opens the Heroku app in the browser.

- **Clean Up (Optional)**:
  - The `clean` target removes the image from the local Docker environment to free up space.

This `Makefile` improves development efficiency by automating common Docker tasks for building and deploying the application to Heroku.