### PR TITLE
Created Root Controller Test

### DIFF
--- a/src/test/java/com/project2/Project2/controller/RootControllerTest.java
+++ b/src/test/java/com/project2/Project2/controller/RootControllerTest.java
@@ -1,0 +1,40 @@
+package com.project2.Project2.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RootControllerTest {
+
+    @InjectMocks
+    private RootController rootController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void home_ShouldReturnWelcomeMessage() {
+        // Arrange
+        String expectedMessage = "Welcome to the API! You can access the following resources:\n" +
+                "- Users: /api/users\n" +
+                "- Books: /api/books\n" +
+                "Please refer to the documentation for more details.";
+
+        // Act
+        String actualMessage = rootController.home();
+
+        // Assert
+        assertEquals(expectedMessage, actualMessage);
+    }
+}
+


### PR DESCRIPTION
**Description:**
This pull request adds unit tests for the `RootController` to verify that the welcome message is returned correctly when the root (`/`) endpoint is accessed.

**Key Features:**

- **Mockito Setup**:
  - The `RootController` is injected using `@InjectMocks`, and `MockitoAnnotations.openMocks()` is used to initialize the mocks before each test.

- **Test Case**:
  - `home_ShouldReturnWelcomeMessage`: Verifies that the `home()` method returns the correct welcome message, including the list of available resources (`/api/users` and `/api/books`), ensuring that the root endpoint behaves as expected.

These tests provide assurance that the `RootController`'s `home()` method functions correctly, returning the expected welcome message.